### PR TITLE
ログの初期化、書き出し

### DIFF
--- a/ConsoleQuest/ConsoleQuest.csproj
+++ b/ConsoleQuest/ConsoleQuest.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/ConsoleQuest/LogData.cs
+++ b/ConsoleQuest/LogData.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ConsoleQuest
+{
+
+	public class LogData
+	{
+		public string Ldata;
+
+	}
+	public class Deserialize
+	{
+
+	}
+	internal class Ldata
+	{
+
+	}
+}

--- a/ConsoleQuest/Logger.cs
+++ b/ConsoleQuest/Logger.cs
@@ -6,6 +6,10 @@ namespace ConsoleQuest
 {
 	public static class Logger
 	{
+
+		private static readonly string LogDataPath =
+		System.IO.Directory.GetCurrentDirectory() + "\\logdata.json";
+
 		private static ILogger LoggerInstance;
 		private static IInput InputInstance;
 
@@ -18,11 +22,18 @@ namespace ConsoleQuest
 		public static void Log(string log)
 		{
 			LoggerInstance?.Log(log);
+			LogData loaddata = new LogData();
+			loaddata.Ldata = log;
+			string jsonData = Newtonsoft.Json.JsonConvert.SerializeObject(loaddata.Ldata);
+			System.IO.File.AppendAllText(LogDataPath, jsonData);
+
 		}
 
 		public static void Log(object log)
 		{
+
 			Log(log.ToString());
+
 		}
 
 
@@ -36,6 +47,7 @@ namespace ConsoleQuest
 	public interface ILogger
 	{
 		void Log(string log);
+
 	}
 
 	public interface IInput
@@ -46,9 +58,15 @@ namespace ConsoleQuest
 
 	public class ConsoleLogger : ILogger
 	{
+
+
+
 		public void Log(string log)
 		{
 			Console.WriteLine(log);
+
+			//string Ldata = new LogData();
+			//Ldata = log.Ldata;
 		}
 	}
 

--- a/ConsoleQuest/Program.cs
+++ b/ConsoleQuest/Program.cs
@@ -4,10 +4,24 @@ namespace ConsoleQuest
 {
 	class Program
 	{
+		private static readonly string LogDataPath =
+		System.IO.Directory.GetCurrentDirectory() + "\\logdata.json";
 		static void Main(string[] args)
 		{
 			Logger.Inject(new ConsoleLogger(), new ConsoleInput());
 
+			//Logdataを宣言
+			LogData loaddata = new LogData();
+
+			try
+			{
+				//ファイル内を初期化
+				string jsonData = System.IO.File.ReadAllText(LogDataPath);
+				jsonData = " ";
+				System.IO.File.WriteAllText(LogDataPath, jsonData);
+			}
+			catch { 
+			}
 			Logger.Log("Start Game!");
 
 			Logger.Log("プレイヤーの名前を入力してください");
@@ -21,8 +35,11 @@ namespace ConsoleQuest
 			World world = new World(player);
 
 			//worldが終了判定(false)を返すまでループ
-			while(world.Loop())
+			while (world.Loop())
 			{
+
+				//jsonData = Newtonsoft.Json.JsonConvert.SerializeObject(loaddata.Ldata);
+				//System.IO.File.AppendAllText(LogDataPath, jsonData);
 				//Enter入力を待つ
 				Logger.ReadInput();
 			}
@@ -30,5 +47,7 @@ namespace ConsoleQuest
 			//THE END
 			Logger.Log("game over.");
 		}
+
+
 	}
 }


### PR DESCRIPTION
20j70033 PG１年　中島樹
ログ用クラスを作ってstring型で書き出ししたものをlogdataファイルに出力し、デバッグの度にそのファイルが初期化されるようにしました
最初はLogDataクラス内でJsonファイルを出力させる予定でしたが失敗して完成しませんでした。
ブランチの作成に失敗したので再々提出になります。
間違えて作ったpull requestは後で消します